### PR TITLE
Clarify usage of the remove-override-from-ns.sh script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,3 +7,4 @@ Lists DeploymentConfigs which do not have a config trigger defined. When Turbono
 ## remove-override-from-ns.sh
 
 Remove `turbo.ibm.com/override` annotations from all workloads in a namespace, allowing the owner to manage compute resources directly. Perform this step **after** the namespace was removed from Turbonomic rightsizing, otherwise the annotations will be restored.
+Note that you need to copy the generated commands and execute them yourself.

--- a/scripts/remove-override-from-ns.sh
+++ b/scripts/remove-override-from-ns.sh
@@ -29,3 +29,5 @@ for KIND in "${KINDS[@]}"; do
      | "oc annotate \($kind) \(.metadata.name) -n \($ns) turbo.ibm.com/override-"' 
 done
 
+echo
+echo "Copy and execute the above commands."


### PR DESCRIPTION
Ran into this while trying to opt-out out of turbonomics for our tenant. Took me longer than I'd like to admit to realize the script never actually executes the oc commands that modify annotations.