### PR TITLE
Remove deprecated exportloopref linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,6 @@ linters:
   enable:
     - dupl
     - errcheck
-    - exportloopref
     - ginkgolinter
     - goconst
     - gocyclo


### PR DESCRIPTION
## Summary

Remove the deprecated `exportloopref` linter from `.golangci.yml`.

## Changes

- Remove `exportloopref` from the enabled linters list in `.golangci.yml`

## Rationale

`exportloopref` was deprecated in golangci-lint v1.60.2. Since Go 1.22, loop variables are scoped per iteration, making this linter unnecessary. Keeping it causes deprecation warnings and may cause CI failures on newer golangci-lint versions.

## Verification

- Confirmed `exportloopref` is listed as deprecated in golangci-lint docs
- No other references to `exportloopref` exist in the repository