### PR TITLE
Fix build and push commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ make test
 ## Building & deploying
 
 ```
-make build . -t <image name>
-podman push <image name>
+make docker-build IMG=<image name>
+make docker-push IMG=<image name>
 make install
 make deploy IMG=<image name>
 ```


### PR DESCRIPTION
## Summary

The README's "Building & deploying" section uses incorrect commands that don't match the Makefile targets.

## Changes

- Replace `make build . -t <image name>` with `make docker-build IMG=<image name>` to match the actual `docker-build` Makefile target
- Replace `podman push <image name>` with `make docker-push IMG=<image name>` to use the Makefile's `docker-push` target, which respects the `CONTAINER_TOOL` variable (works with both docker and podman)

## Verification

- Confirmed `docker-build` and `docker-push` targets exist in the Makefile (lines 143-149)
- Confirmed `docker-build` runs `$(CONTAINER_TOOL) build -t ${IMG} .` and `docker-push` runs `$(CONTAINER_TOOL) push ${IMG}`
- There is no `build` target that accepts `. -t` arguments; that syntax conflates Make targets with raw container CLI flags