### PR TITLE
Fix incomplete error message in certificate watcher initialization

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -210,7 +210,7 @@ func addCertPath(tlsOpts []func(*tls.Config), certPath string) []func(*tls.Confi
 		filepath.Join(certPath, "tls.key"),
 	)
 	if err != nil {
-		setupLog.Error(err, "to initialize certificate watcher", "error", err)
+		setupLog.Error(err, "failed to initialize certificate watcher")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Summary

Fix the error log message in `addCertPath()` which was missing the "failed" prefix, making it read as a sentence fragment rather than a proper error description. Also remove the redundant `"error", err` key-value pair since `logr.Error()` already includes the error as its first argument.

## Changes

- Add missing "failed" prefix to certificate watcher error message in `cmd/main.go`
- Remove redundant error key-value pair that duplicated the error already passed as the first argument to `setupLog.Error()`

## Verification

- Reviewed `logr.Error` API: the first argument is the error itself, so passing `"error", err` as a structured field duplicates it
- Confirmed all other `setupLog.Error` calls in the same file follow the corrected pattern (e.g., `"unable to start manager"`, `"unable to set up health check"`)